### PR TITLE
Bugfix/1 artikel prefix issue

### DIFF
--- a/law_lookup/lookup.py
+++ b/law_lookup/lookup.py
@@ -39,7 +39,7 @@ class LawLookup:
         if len(parts) >= 3:
             section_number = parts[1]  # Gets '1' from '§ 1 BGB' or 'Art. 1 GG'
             law = parts[-1]  # Gets 'BGB' from '§ 1 BGB' or 'GG' from 'Art. 1 GG'
-            if parts[0] != '§':
+            if parts[0] != '§':  # Effectively, this checks for the 'Art.'
                 uses_paragraph_symbol = False
             return section_number, law, uses_paragraph_symbol
         return None, None, None
@@ -77,5 +77,5 @@ class LawLookup:
             first_reference = self.get_first_reference(tokens)
             if first_reference:
                 section_number, law, uses_paragraph_symbol = self.get_expression_slices(first_reference)
-                if section_number and law:
+                if section_number and law:  # Only check for this, so it opens even if it's an 'Artikel' not a '§'
                     self.get_reference(section_number, law, uses_paragraph_symbol)

--- a/law_lookup/lookup.py
+++ b/law_lookup/lookup.py
@@ -39,7 +39,7 @@ class LawLookup:
         if len(parts) >= 3:
             section_number = parts[1]  # Gets '1' from '§ 1 BGB' or 'Art. 1 GG'
             law = parts[-1]  # Gets 'BGB' from '§ 1 BGB' or 'GG' from 'Art. 1 GG'
-            if parts[0] == 'Art.':
+            if parts[0] != '§':
                 uses_paragraph_symbol = False
             return section_number, law, uses_paragraph_symbol
         return None, None, None
@@ -50,11 +50,12 @@ class LawLookup:
     
     def get_reference(self, section_number, law, uses_paragraph_symbol):
         law_code = self.law_map_lookup(law)
-        if uses_paragraph_symbol == True:
-            url = f"https://www.gesetze-im-internet.de/{law_code}/__{section_number}.html"
-        else:
-            url = f"https://www.gesetze-im-internet.de/{law_code}/art_{section_number}.html"
-        webbrowser.open(url)
+        if law_code:  # Check if law_code is found in the mapping
+            if uses_paragraph_symbol:
+                url = f"https://www.gesetze-im-internet.de/{law_code}/__{section_number}.html"
+            else:
+                url = f"https://www.gesetze-im-internet.de/{law_code}/art_{section_number}.html"
+            webbrowser.open(url)
     
     def install_hooks(self):
         Reviewer._showQuestion = wrap(Reviewer._showQuestion, self._on_reviewer_show_question, "after")
@@ -76,5 +77,5 @@ class LawLookup:
             first_reference = self.get_first_reference(tokens)
             if first_reference:
                 section_number, law, uses_paragraph_symbol = self.get_expression_slices(first_reference)
-                if section_number and law and uses_paragraph_symbol:
+                if section_number and law:
                     self.get_reference(section_number, law, uses_paragraph_symbol)

--- a/law_lookup/lookup.py
+++ b/law_lookup/lookup.py
@@ -29,30 +29,31 @@ class LawLookup:
     
     def get_first_reference(self, tokens):
         for token in tokens:
-            if token.startswith('§'):
+            if token.startswith('§') or token.startswith('Art.'):
                 return token
-        return None  # If no token starts with '§', we do not have any reference
+        return None  # If no token starts with '§' or 'Art.', we do not have any reference
     
     def get_expression_slices(self, first_reference):
         parts = first_reference.split()
+        uses_paragraph_symbol = True
         if len(parts) >= 3:
-            section_number = parts[1]  # Gets '1' from '§ 1 BGB'
-            law = parts[-1]  # Gets 'BGB' from '§ 1 BGB'
-            return section_number, law
-        return None, None
-    
-    def get_reference(self, section_number, law):
-        law = law.lower()
-        url = f"https://www.gesetze-im-internet.de/{law}/__{section_number}.html"
-        webbrowser.open(url) 
+            section_number = parts[1]  # Gets '1' from '§ 1 BGB' or 'Art. 1 GG'
+            law = parts[-1]  # Gets 'BGB' from '§ 1 BGB' or 'GG' from 'Art. 1 GG'
+            if parts[0] == 'Art.':
+                uses_paragraph_symbol = False
+            return section_number, law, uses_paragraph_symbol
+        return None, None, None
     
     def law_map_lookup(self, law):
         # Lookup the corresponding value in law_mapping.json
         return self.law_map.get(law, None)
     
-    def get_reference(self, section_number, law):
+    def get_reference(self, section_number, law, uses_paragraph_symbol):
         law_code = self.law_map_lookup(law)
-        url = f"https://www.gesetze-im-internet.de/{law_code}/__{section_number}.html"
+        if uses_paragraph_symbol == True:
+            url = f"https://www.gesetze-im-internet.de/{law_code}/__{section_number}.html"
+        else:
+            url = f"https://www.gesetze-im-internet.de/{law_code}/art_{section_number}.html"
         webbrowser.open(url)
     
     def install_hooks(self):
@@ -74,6 +75,6 @@ class LawLookup:
             tokens = self.tokenize_front_card(card)
             first_reference = self.get_first_reference(tokens)
             if first_reference:
-                section_number, law = self.get_expression_slices(first_reference)
-                if section_number and law:
-                    self.get_reference(section_number, law)
+                section_number, law, uses_paragraph_symbol = self.get_expression_slices(first_reference)
+                if section_number and law and uses_paragraph_symbol:
+                    self.get_reference(section_number, law, uses_paragraph_symbol)

--- a/law_lookup/tokenizer_german_legal_jargon.py
+++ b/law_lookup/tokenizer_german_legal_jargon.py
@@ -1,4 +1,5 @@
 # Use my old GitLab snippet for tokenizing: https://gitlab.com/-/snippets/3622982
+# Mind that this snipped did contain a bug that is fixed here (see Bugfix #1 below)
 
 import re
 
@@ -99,12 +100,9 @@ def tokenizer_german_legal_texts(text):
             current_element = tokens[index]             
             next_element = tokens[index + 1]        
             # Merge tokens via "§"
-            if current_element.startswith("§") or current_element.startswith("Art."): # Bugfix
+            if current_element.startswith("§") or current_element.startswith("Art."): # Bugfix #1
                 tokens[index] = current_element + " " + next_element
                 tokens.pop(index + 1)
         except IndexError:
             pass
     return tokens
-
-# Debug-statements
-# print(tokenizer_german_legal_texts("Art. 1 Abs. 1 GG"))

--- a/law_lookup/tokenizer_german_legal_jargon.py
+++ b/law_lookup/tokenizer_german_legal_jargon.py
@@ -99,9 +99,12 @@ def tokenizer_german_legal_texts(text):
             current_element = tokens[index]             
             next_element = tokens[index + 1]        
             # Merge tokens via "§"
-            if current_element.startswith("§"):
+            if current_element.startswith("§") or current_element.startswith("Art."): # Bugfix
                 tokens[index] = current_element + " " + next_element
                 tokens.pop(index + 1)
         except IndexError:
             pass
     return tokens
+
+# Debug-statements
+# print(tokenizer_german_legal_texts("Art. 1 Abs. 1 GG"))


### PR DESCRIPTION
This pull request is made for fixing the issue bugfix/1, where it wouldn't open a website if the citated norm started with 'Art.'.  This happend due to several factors:

- the lookup.py didn't provide any support for this, since the URL looked a bit different
- the tokenizer.py didn't merge the tokens start (like 'Art. 1 Abs. 1') with the law ('GG') since the main method didn't check for a startswith('Art.'), only for a startswith('§')

I tested it on my Windows-PC and it now works like a charm. 